### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Dependencies
         run: ./run.sh install_deps
 
+      - name: System Dependencies
+        run: ./run.sh install_aptget libgsl-dev
+
       - name: Test
         run: ./run.sh run_tests
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 env:
-  USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
 
 jobs:
@@ -21,13 +20,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
-      - name: Bootstrap
-        run: |
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
-          chmod 0755 run.sh
-          ./run.sh bootstrap
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci@master
 
       - name: Dependencies
         run: ./run.sh install_deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,13 @@ jobs:
       - name: Test
         run: ./run.sh run_tests
 
+      - name: Logs
+        run: ./run.sh dump_logs
+        if: failure()
+
       #- name: Coverage
       #  if: ${{ matrix.os == 'ubuntu-latest' }}
       #  run: ./run.sh coverage
+      #  env:
+      #    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+


### PR DESCRIPTION
I tend to go over `ci.yaml` in my repos somewhat regularly, and noticed the copy here had drifted a little. This PR updates two (or three) aspects:

- update to the current reference version (in repo [r-ci](https://github.com/eddelbuettel/r-ci)) notably using checkout action v7, and relying on my setup action
- correct an actual defect in that `libgsl-dev` needs to be installed to build the package from source on Ubuntu
- add usage of the codecov token in the (still commented-out) coverage part (which I use elsewhere)

This now again successfully run the continunous integration, and could (if desired) do the coverage as well -- I do so in other repos as e.g. [RcppArmadillo](https://github.com/RcppCore/RcppArmadillo/blob/master/.github/workflows/ci.yaml#L53-L57) using the same script